### PR TITLE
Take over mode

### DIFF
--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -44,7 +44,6 @@
 	"settings": {
 		"volar.codeLens.references": true,
 		"volar.codeLens.pugTools": false,
-		"volar.autoCompleteRefs": true,
 		"volar.codeLens.scriptSetupTools": false,
 		"volar.completion.autoImportComponent": true,
 		"volar.preferredAttrNameCase": "auto-kebab",

--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -41,6 +41,16 @@
 			}
 		}
 	},
+	"settings": {
+		"volar.codeLens.references": true,
+		"volar.codeLens.pugTools": false,
+		"volar.autoCompleteRefs": true,
+		"volar.codeLens.scriptSetupTools": false,
+		"volar.completion.autoImportComponent": true,
+		"volar.preferredAttrNameCase": "auto-kebab",
+		"volar.preferredTagNameCase": "auto",
+		"volar.takeOverMode.enabled": "auto"
+	},
 	"languages": [
 		{
 			"languageId": "vue",

--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -48,8 +48,17 @@
 		"volar.codeLens.scriptSetupTools": false,
 		"volar.completion.autoImportComponent": true,
 		"volar.preferredAttrNameCase": "auto-kebab",
-		"volar.preferredTagNameCase": "auto",
-		"volar.takeOverMode.enabled": "auto"
+		"volar.preferredTagNameCase": "auto"
 	},
-	"selector": "text.html.vue"
+	"languages": [
+		{
+			"languageId": "vue",
+			// ST3
+			"scopes": ["text.html.vue"],
+			"syntaxes": ["Packages/Vue Syntax Highlight/Vue Component.sublime-syntax"],
+			// ST4
+			"document_selector": "text.html.vue",
+			"feature_selector": "text.html.vue",
+		}
+	]
 }

--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -60,6 +60,15 @@
 			// ST4
 			"document_selector": "text.html.vue",
 			"feature_selector": "text.html.vue",
-		}
+		},
+		{
+			"languageId": "typescript",
+			// ST3
+			"scopes": ["source.ts"],
+			"syntaxes": ["Packages/TypeScript Syntax/TypeScript.tmLanguage"],
+			// ST4
+			"document_selector": "source.ts",
+			"feature_selector": "source.ts",
+		},
 	]
 }

--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -62,13 +62,32 @@
 			"feature_selector": "text.html.vue",
 		},
 		{
+			"languageId": "typescriptreact",
+			// ST3
+			"scopes": ["source.tsx"],
+			"syntaxes": [
+				"Packages/TypeScript Syntax/TypeScriptReact.tmLanguage",
+			],
+			// ST4
+			"document_selector": "source.tsx"
+		},
+		{
 			"languageId": "typescript",
 			// ST3
 			"scopes": ["source.ts"],
 			"syntaxes": ["Packages/TypeScript Syntax/TypeScript.tmLanguage"],
 			// ST4
-			"document_selector": "source.ts",
-			"feature_selector": "source.ts",
+			"document_selector": "source.ts"
+		},
+		{
+			"languageId": "javascriptreact",
+			// ST3
+			"scopes": ["source.jsx", "source.js.react"],
+			"syntaxes": [
+				"Packages/User/JS Custom/Syntaxes/React.sublime-syntax",
+			],
+			// ST4
+			"document_selector": "source.jsx"
 		},
 		{
 			"languageId": "javascript",
@@ -79,8 +98,7 @@
 				"Packages/Babel/JavaScript (Babel).sublime-syntax",
 			],
 			// ST4
-			"document_selector": "source.js",
-			"feature_selector": "source.js",
+			"document_selector": "source.js"
 		},
 	]
 }

--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -51,54 +51,5 @@
 		"volar.preferredTagNameCase": "auto",
 		"volar.takeOverMode.enabled": "auto"
 	},
-	"languages": [
-		{
-			"languageId": "vue",
-			// ST3
-			"scopes": ["text.html.vue"],
-			"syntaxes": ["Packages/Vue Syntax Highlight/Vue Component.sublime-syntax"],
-			// ST4
-			"document_selector": "text.html.vue",
-			"feature_selector": "text.html.vue",
-		},
-		{
-			"languageId": "typescriptreact",
-			// ST3
-			"scopes": ["source.tsx"],
-			"syntaxes": [
-				"Packages/TypeScript Syntax/TypeScriptReact.tmLanguage",
-			],
-			// ST4
-			"document_selector": "source.tsx"
-		},
-		{
-			"languageId": "typescript",
-			// ST3
-			"scopes": ["source.ts"],
-			"syntaxes": ["Packages/TypeScript Syntax/TypeScript.tmLanguage"],
-			// ST4
-			"document_selector": "source.ts"
-		},
-		{
-			"languageId": "javascriptreact",
-			// ST3
-			"scopes": ["source.jsx", "source.js.react"],
-			"syntaxes": [
-				"Packages/User/JS Custom/Syntaxes/React.sublime-syntax",
-			],
-			// ST4
-			"document_selector": "source.jsx"
-		},
-		{
-			"languageId": "javascript",
-			// ST3
-			"scopes": ["source.js"],
-			"syntaxes": [
-				"Packages/JavaScript/JavaScript.sublime-syntax",
-				"Packages/Babel/JavaScript (Babel).sublime-syntax",
-			],
-			// ST4
-			"document_selector": "source.js"
-		},
-	]
+	"selector": "text.html.vue"
 }

--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -70,5 +70,17 @@
 			"document_selector": "source.ts",
 			"feature_selector": "source.ts",
 		},
+		{
+			"languageId": "javascript",
+			// ST3
+			"scopes": ["source.js"],
+			"syntaxes": [
+				"Packages/JavaScript/JavaScript.sublime-syntax",
+				"Packages/Babel/JavaScript (Babel).sublime-syntax",
+			],
+			// ST4
+			"document_selector": "source.js",
+			"feature_selector": "source.js",
+		},
 	]
 }

--- a/README.md
+++ b/README.md
@@ -12,19 +12,50 @@ This is a helper package that automatically installs and updates the
 
 Open configuration file using command palette with `Preferences: LSP-volar Settings` command or opening it from the Sublime menu (`Preferences > Package Settings > LSP > Servers > LSP-volar`).
 
-
 ### Take over mode
 
-Allow LSP-volar to start in `*.ts` and `*.js` files.
+Allow LSP-volar to start in `*.ts | *.tsx | *.js | *.jsx` files.
 
-To enable take over mode, from the command palette select `Preferences: LSP-volar Settings` and put the following in `LSP-volar.sublime-settings`.
+You can enable the take over mode:
+- per project
+- globally
+
+#### Per project
+
+Create a sublime project file with the following contents:
 
 ```
 {
+	"folders":
+	[
+		{
+			"path": "."
+		}
+	],
 	"settings": {
-		"volar.takeOverMode.enabled": true
+		"LSP": {
+			"LSP-volar": {
+				"selector": "text.html.vue | source.ts | source.tsx | source.js | source.jsx"
+			},
+			"LSP-typescript": {
+				"enabled": false
+			}
+		}
 	}
 }
 ```
 
-It is advisable to disable the LSP-typescript package to avoid showing duplicate results.
+#### Globally
+
+From the command palette select `Preferences: LSP-volar Settings` and paste the following:
+
+```
+// Settings in here override those in "LSP-volar/LSP-volar.sublime-settings"
+
+{
+	"selector": "source.vue | source.ts | source.tsx | source.js | source.jsx"
+}
+```
+
+> NOTE: It is advisable to disable the LSP-typescript package when in take over mode to avoid showing duplicate results.
+

--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ This is a helper package that automatically installs and updates the
 
 Open configuration file using command palette with `Preferences: LSP-volar Settings` command or opening it from the Sublime menu (`Preferences > Package Settings > LSP > Servers > LSP-volar`).
 
+
+### Take over mode
+
+Allow LSP-volar to start in `*.ts` and `*.js` files.
+
+To enable take over mode, from the command palette select `Preferences: LSP-volar Settings` and put the following in `LSP-volar.sublime-settings`.
+
+```
+{
+	"settings": {
+		"volar.takeOverMode.enabled": true
+	}
+}
+```
+
+It is advisebale to disable the LSP-typescript plugin to avoid showing duplicate results.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open configuration file using command palette with `Preferences: LSP-volar Setti
 
 Allow LSP-volar to start in `*.ts | *.tsx | *.js | *.jsx` files.
 
-#### Per project configuration
+#### Per project:
 
 Create a sublime project file with the following contents:
 
@@ -41,7 +41,7 @@ Create a sublime project file with the following contents:
 }
 ```
 
-#### Global configuration
+#### Globally:
 
 From the command palette select `Preferences: LSP-volar Settings` and paste the following:
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@ This is a helper package that automatically installs and updates the
 
 Open configuration file using command palette with `Preferences: LSP-volar Settings` command or opening it from the Sublime menu (`Preferences > Package Settings > LSP > Servers > LSP-volar`).
 
-### Take over mode
+### Enable for non-Vue files
 
 Allow LSP-volar to start in `*.ts | *.tsx | *.js | *.jsx` files.
 
-You can enable the take over mode:
-- per project
-- globally
-
-#### Per project
+#### Per project configuration
 
 Create a sublime project file with the following contents:
 
@@ -45,7 +41,7 @@ Create a sublime project file with the following contents:
 }
 ```
 
-#### Globally
+#### Global configuration
 
 From the command palette select `Preferences: LSP-volar Settings` and paste the following:
 
@@ -57,5 +53,5 @@ From the command palette select `Preferences: LSP-volar Settings` and paste the 
 }
 ```
 
-> NOTE: It is advisable to disable the LSP-typescript package when in take over mode to avoid showing duplicate results.
+> NOTE: When enabling LSP-volar for non-Vue files, it is advisable to disable the LSP-typescript package to avoid showing duplicate results.
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ To enable take over mode, from the command palette select `Preferences: LSP-vola
 }
 ```
 
-It is advisebale to disable the LSP-typescript plugin to avoid showing duplicate results.
+It is advisable to disable the LSP-typescript package to avoid showing duplicate results.

--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ Create a sublime project file with the following contents:
 
 ```
 {
-	"folders":
-	[
-		{
-			"path": "."
-		}
-	],
-	"settings": {
-		"LSP": {
-			"LSP-volar": {
-				"selector": "text.html.vue | source.ts | source.tsx | source.js | source.jsx"
-			},
-			"LSP-typescript": {
-				"enabled": false
-			}
-		}
-	}
+    "folders":
+    [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        "LSP": {
+            "LSP-volar": {
+                "selector": "text.html.vue | source.ts | source.tsx | source.js | source.jsx"
+            },
+            "LSP-typescript": {
+                "enabled": false
+            }
+        }
+    }
 }
 ```
 
@@ -53,7 +53,7 @@ From the command palette select `Preferences: LSP-volar Settings` and paste the 
 // Settings in here override those in "LSP-volar/LSP-volar.sublime-settings"
 
 {
-	"selector": "source.vue | source.ts | source.tsx | source.js | source.jsx"
+    "selector": "source.vue | source.ts | source.tsx | source.js | source.jsx"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ From the command palette select `Preferences: LSP-volar Settings` and paste the 
 // Settings in here override those in "LSP-volar/LSP-volar.sublime-settings"
 
 {
-    "selector": "source.vue | source.ts | source.tsx | source.js | source.jsx"
+    "selector": "text.html.vue | source.ts | source.tsx | source.js | source.jsx"
 }
 ```
 

--- a/plugin.py
+++ b/plugin.py
@@ -22,15 +22,8 @@ class LspVolarPlugin(NpmClientHandler):
 
     @classmethod
     def on_client_configuration_ready(cls, configuration: dict) -> None:
-        is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled")
+        is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled", False)
         take_over_mode = configuration.get("settings", {}).get("volar.takeOverMode.enabled", "auto") # type: Union[str, bool]
-
-        # Check if LSP-typescirpt is disbled in the project
-        project_data = sublime.active_window().project_data()
-        if project_data:
-            is_enabled_in_project = project_data.get('settings', {}).get("LSP", {}).get("LSP-typescript", {}).get("enabled")  # type: Optional[bool]
-            if is_enabled_in_project is not None:
-                is_lsp_typescript_enabled = is_enabled_in_project
 
         def dont_start_in_typescript_files():
             languages = configuration.get("languages", [])

--- a/plugin.py
+++ b/plugin.py
@@ -27,7 +27,7 @@ class LspVolarPlugin(NpmClientHandler):
 
         def dont_start_in_ts_and_js_files():
             languages = configuration.get("languages", [])
-            languages_without_typescript = list(filter(lambda langDict: langDict.get('languageId') not in ['typescript', "javascript"], languages))
+            languages_without_typescript = list(filter(lambda langDict: langDict.get('languageId') not in ['typescript', "typescriptreact", "javascript", "javascriptreact"], languages))
             configuration['languages'] = languages_without_typescript
 
         if take_over_mode == "auto" and is_lsp_typescript_enabled:

--- a/plugin.py
+++ b/plugin.py
@@ -22,8 +22,15 @@ class LspVolarPlugin(NpmClientHandler):
 
     @classmethod
     def on_client_configuration_ready(cls, configuration: dict) -> None:
-        is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled", False)
+        is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled")
         take_over_mode = configuration.get("settings", {}).get("volar.takeOverMode.enabled", "auto") # type: Union[str, bool]
+
+        # Check if LSP-typescirpt is disbled in the project
+        project_data = sublime.active_window().project_data()
+        if project_data:
+            is_enabled_in_project = project_data.get('settings', {}).get("LSP", {}).get("LSP-typescript", {}).get("enabled")  # type: Optional[bool]
+            if is_enabled_in_project is not None:
+                is_lsp_typescript_enabled = is_enabled_in_project
 
         def dont_start_in_typescript_files():
             languages = configuration.get("languages", [])

--- a/plugin.py
+++ b/plugin.py
@@ -25,6 +25,19 @@ class LspVolarPlugin(NpmClientHandler):
         is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled")
         take_over_mode = configuration.get("settings", {}).get("volar.takeOverMode.enabled", "auto") # type: Union[str, bool]
 
+        # Check if LSP-typescirpt is disbled in the project
+        project_data = sublime.active_window().project_data()
+        if project_data:
+            is_enabled_in_project = project_data.get('settings', {}).get("LSP", {}).get("LSP-typescript", {}).get("enabled")  # type: Optional[bool]
+            if is_enabled_in_project is not None:
+                is_lsp_typescript_enabled = is_enabled_in_project
+
+            take_over_mode_in_project = project_data.get('settings', {}).get("LSP", {}).get("LSP-volar", {}).get("settings", {}).get("volar.takeOverMode.enabled")  # type: Optional[Union[str, bool]]
+            if take_over_mode_in_project is not None:
+                take_over_mode = take_over_mode_in_project
+
+        print('is_lsp_typescript_enabled', is_lsp_typescript_enabled)
+        print('take_over_mode', take_over_mode)
         def dont_start_in_ts_and_js_files():
             languages = configuration.get("languages", [])
             languages_without_typescript = list(filter(lambda langDict: langDict.get('languageId') not in ['typescript', "typescriptreact", "javascript", "javascriptreact"], languages))

--- a/plugin.py
+++ b/plugin.py
@@ -32,9 +32,9 @@ class LspVolarPlugin(NpmClientHandler):
 
         if take_over_mode == "auto" and is_lsp_typescript_enabled:
             dont_start_in_ts_and_js_files()
-        if take_over_mode == False:
+        if take_over_mode is False:
             dont_start_in_ts_and_js_files()
-        if take_over_mode == True and is_lsp_typescript_enabled:
+        if take_over_mode is True and is_lsp_typescript_enabled:
             sublime.status_message('LSP-volar: \"volar.takeOverMode.enabled\" is enabled. Disable "LSP-typescript" or "LSP-volar" to avoid duplicate results.')
 
     @classmethod

--- a/plugin.py
+++ b/plugin.py
@@ -25,23 +25,16 @@ class LspVolarPlugin(NpmClientHandler):
         is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled")
         take_over_mode = configuration.get("settings", {}).get("volar.takeOverMode.enabled", "auto") # type: Union[str, bool]
 
-        # Check if LSP-typescirpt is disbled in the project
-        project_data = sublime.active_window().project_data()
-        if project_data:
-            is_enabled_in_project = project_data.get('settings', {}).get("LSP", {}).get("LSP-typescript", {}).get("enabled")  # type: Optional[bool]
-            if is_enabled_in_project is not None:
-                is_lsp_typescript_enabled = is_enabled_in_project
-
-        def dont_start_in_typescript_files():
+        def dont_start_in_ts_and_js_files():
             languages = configuration.get("languages", [])
-            languages_without_typescript = list(filter(lambda langDict: langDict.get('languageId') != 'typescript', languages))
+            languages_without_typescript = list(filter(lambda langDict: langDict.get('languageId') not in ['typescript', "javascript"], languages))
             configuration['languages'] = languages_without_typescript
 
-        if (take_over_mode == "auto" and is_lsp_typescript_enabled):
-            dont_start_in_typescript_files()
-        if (take_over_mode == False):
-            dont_start_in_typescript_files()
-        if (take_over_mode == True and is_lsp_typescript_enabled):
+        if take_over_mode == "auto" and is_lsp_typescript_enabled:
+            dont_start_in_ts_and_js_files()
+        if take_over_mode == False:
+            dont_start_in_ts_and_js_files()
+        if take_over_mode == True and is_lsp_typescript_enabled:
             sublime.status_message('LSP-volar: \"volar.takeOverMode.enabled\" is enabled. Disable "LSP-typescript" or "LSP-volar" to avoid duplicate results.')
 
     @classmethod

--- a/plugin.py
+++ b/plugin.py
@@ -21,36 +21,6 @@ class LspVolarPlugin(NpmClientHandler):
     server_binary_path = os.path.join(server_directory, 'node_modules', '@volar', 'server', 'out', 'index.js')
 
     @classmethod
-    def on_client_configuration_ready(cls, configuration: dict) -> None:
-        is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled")
-        take_over_mode = configuration.get("settings", {}).get("volar.takeOverMode.enabled", "auto") # type: Union[str, bool]
-
-        # Check if LSP-typescirpt is disbled in the project
-        project_data = sublime.active_window().project_data()
-        if project_data:
-            is_enabled_in_project = project_data.get('settings', {}).get("LSP", {}).get("LSP-typescript", {}).get("enabled")  # type: Optional[bool]
-            if is_enabled_in_project is not None:
-                is_lsp_typescript_enabled = is_enabled_in_project
-
-            take_over_mode_in_project = project_data.get('settings', {}).get("LSP", {}).get("LSP-volar", {}).get("settings", {}).get("volar.takeOverMode.enabled")  # type: Optional[Union[str, bool]]
-            if take_over_mode_in_project is not None:
-                take_over_mode = take_over_mode_in_project
-
-        print('is_lsp_typescript_enabled', is_lsp_typescript_enabled)
-        print('take_over_mode', take_over_mode)
-        def dont_start_in_ts_and_js_files():
-            languages = configuration.get("languages", [])
-            languages_without_typescript = list(filter(lambda langDict: langDict.get('languageId') not in ['typescript', "typescriptreact", "javascript", "javascriptreact"], languages))
-            configuration['languages'] = languages_without_typescript
-
-        if take_over_mode == "auto" and is_lsp_typescript_enabled:
-            dont_start_in_ts_and_js_files()
-        if take_over_mode is False:
-            dont_start_in_ts_and_js_files()
-        if take_over_mode is True and is_lsp_typescript_enabled:
-            sublime.status_message('LSP-volar: \"volar.takeOverMode.enabled\" is enabled. Disable "LSP-typescript" or "LSP-volar" to avoid duplicate results.')
-
-    @classmethod
     def is_allowed_to_start(
         cls,
         window: sublime.Window,

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,6 @@
 from LSP.plugin import ClientConfig
 from LSP.plugin import WorkspaceFolder
-from LSP.plugin.core.typing import List, Optional, Union
+from LSP.plugin.core.typing import List, Optional
 from lsp_utils import NpmClientHandler
 import os
 import sublime

--- a/plugin.py
+++ b/plugin.py
@@ -22,7 +22,7 @@ class LspVolarPlugin(NpmClientHandler):
 
     @classmethod
     def on_client_configuration_ready(cls, configuration: dict) -> None:
-        is_lsp_typescript_installed = bool(sublime.find_resources("LSP-typescript.sublime-commands"))
+        is_lsp_typescript_enabled = sublime.load_settings("LSP-typescript.sublime-settings").get("enabled", False)
         take_over_mode = configuration.get("settings", {}).get("volar.takeOverMode.enabled", "auto") # type: Union[str, bool]
 
         def dont_start_in_typescript_files():
@@ -30,11 +30,11 @@ class LspVolarPlugin(NpmClientHandler):
             languages_without_typescript = list(filter(lambda langDict: langDict.get('languageId') != 'typescript', languages))
             configuration['languages'] = languages_without_typescript
 
-        if (take_over_mode == "auto" and is_lsp_typescript_installed):
+        if (take_over_mode == "auto" and is_lsp_typescript_enabled):
             dont_start_in_typescript_files()
         if (take_over_mode == False):
             dont_start_in_typescript_files()
-        if (take_over_mode == True and is_lsp_typescript_installed):
+        if (take_over_mode == True and is_lsp_typescript_enabled):
             sublime.status_message('LSP-volar: \"volar.takeOverMode.enabled\" is enabled. Disable "LSP-typescript" or "LSP-volar" to avoid duplicate results.')
 
     @classmethod

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -20,12 +20,12 @@
                     },
                     "volar.codeLens.pugTools": {
                       "type": "boolean",
-                      "default": true,
+                      "default": false,
                       "description": "[pug ☐] code lens."
                     },
                     "volar.codeLens.scriptSetupTools": {
                       "type": "boolean",
-                      "default": true,
+                      "default": false,
                       "description": "[ref sugar ☐] code lens."
                     },
                     "volar.autoCompleteRefs": {
@@ -33,25 +33,20 @@
                       "default": true,
                       "description": "Auto-complete Ref value with `.value`."
                     },
-                    "volar.tsPlugin": {
-                      "type": "boolean",
+                    "volar.takeOverMode.enabled": {
+                      "type": ["boolean", "string"],
                       "enum": [
-                        null,
+                        "auto",
                         true,
                         false
                       ],
                       "enumDescriptions": [
-                        "Don't care (Don't reload VSCode)",
-                        "Enable TS Plugin",
-                        "Disable TS Plugin"
+                        "Auto enable take over mode when built-in TS extension disabled.",
+                        "Alway enable take over mode.",
+                        "Never enable take over mode."
                       ],
-                      "default": null,
-                      "description": "Enable Vue TS Server Plugin.\nSince TypeScript cannot handle type information for `.vue` imports, they are shimmed to be a generic Vue component type by default. In most cases, this is fine if you don't really care about component prop types outside of templates. However, if you wish to get actual prop types in `.vue` imports (for example to get props validation when using manual `h(...)` calls), then you need to enable this setting."
-                    },
-                    "volar.tsPluginStatus": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Display TS Server Plugin status bar item."
+                      "default": "auto",
+                      "description": "Take over language support for *.ts."
                     },
                     "volar.preferredTagNameCase": {
                       "type": "string",
@@ -87,20 +82,10 @@
                       "default": "auto-kebab",
                       "description": "Preferred attr name case."
                     },
-                    "volar.preview.port": {
-                      "type": "number",
-                      "default": 3333,
-                      "description": "Default port for component preview server."
-                    },
-                    "volar.preview.backgroundColor": {
-                      "type": "string",
-                      "default": "#fff",
-                      "description": "Component preview background color."
-                    },
-                    "volar.preview.transparentGrid": {
+                    "volar.completion.autoImportComponent": {
                       "type": "boolean",
                       "default": true,
-                      "description": "Component preview background style."
+                      "description": "Enabled auto-import for component with tag completion."
                     }
                   }
                 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -28,11 +28,6 @@
                       "default": false,
                       "description": "[ref sugar ☐] code lens."
                     },
-                    "volar.autoCompleteRefs": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Auto-complete Ref value with `.value`."
-                    },
                     "volar.preferredTagNameCase": {
                       "type": "string",
                       "enum": [

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -33,21 +33,6 @@
                       "default": true,
                       "description": "Auto-complete Ref value with `.value`."
                     },
-                    "volar.takeOverMode.enabled": {
-                      "type": ["boolean", "string"],
-                      "enum": [
-                        "auto",
-                        true,
-                        false
-                      ],
-                      "enumDescriptions": [
-                        "Auto enable take over mode when built-in TS extension disabled.",
-                        "Alway enable take over mode.",
-                        "Never enable take over mode."
-                      ],
-                      "default": "auto",
-                      "description": "Take over language support for *.ts."
-                    },
                     "volar.preferredTagNameCase": {
                       "type": "string",
                       "enum": [


### PR DESCRIPTION
This PR allows volar to start in ts files. 

```
"volar.takeOverMode.enabled": {
  "type": ["boolean", "string"],
  "enum": ["auto", true, false ],
  "enumDescriptions": [
    "Auto enable take over mode when built-in TS extension disabled.",
    "Alway enable take over mode.",
    "Never enable take over mode."
  ],
  "default": "auto",
  "description": "Take over language support for *.ts."
},
```

<strike>But there is one problem.</strike> 
This <strike>doesn't</strike> works :)

-----

<strike>Note: it is a client problem, everything is ok on the server</strike>

