### PR TITLE
Add support for yarn pnp

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -35,7 +35,7 @@ class LspVolarPlugin(NpmClientHandler):
         server_directory_path = cls._server_directory_path()
         resolve_module_script = os.path.join(server_directory_path, 'resolve_module.js')
         first_folder = workspace_folders[0].path
-        command =  [cls._node_bin(), resolve_module_script, first_folder, 'typescript/lib/tsserverlibrary.js']
+        find_ts_server_command =  [cls._node_bin(), resolve_module_script, first_folder]
         startupinfo = None
         # Prevent cmd.exe popup on Windows.
         if sublime.platform() == "windows":
@@ -43,6 +43,6 @@ class LspVolarPlugin(NpmClientHandler):
             startupinfo.dwFlags |= (
                 subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW
             )
-        workspace_ts_path = subprocess.check_output(command, universal_newlines=True, startupinfo=startupinfo)
+        workspace_ts_path = subprocess.check_output(find_ts_server_command, universal_newlines=True, startupinfo=startupinfo)
         bundled_ts_path = os.path.join(server_directory_path, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js')
         configuration.init_options.set('typescript.serverPath', workspace_ts_path or bundled_ts_path)

--- a/server/resolve_module.js
+++ b/server/resolve_module.js
@@ -1,7 +1,31 @@
+// implementation found at:
+// https://github.com/typescript-language-server/typescript-language-server/blob/6fe20dac1c28c684cf3214bfdbd98f05225090b9/src/utils/modules-resolver.ts
+const fs = require('fs');
+const path = require('path');
+
 try {
 	const workspaceDir = process.argv[2]
-	const module = process.argv[3]
-	process.stdout.write(require.resolve(module, { paths: [workspaceDir] }));
+	process.stdout.write(findPathToModule(workspaceDir) || "");
 } catch {
 	// ignore error if module not found
+}
+
+/**
+ * @param      {string}    dir
+ * @return     {(string|undefined)}
+ */
+function findPathToModule(dir) {
+    const MODULE_PATHS = ['node_modules/typescript/lib/tsserverlibrary.js', '.vscode/pnpify/typescript/lib/tsserverlibrary.js', '.yarn/sdks/typescript/lib/tsserverlibrary.js']
+    const stat = fs.statSync(dir);
+    if (stat.isDirectory()) {
+        const candidates = MODULE_PATHS.map(moduleName => path.resolve(dir, moduleName));
+        const modulePath = candidates.find(fs.existsSync);
+        if (modulePath) {
+            return modulePath;
+        }
+    }
+    const parent = path.resolve(dir, '..');
+    if (parent !== dir) {
+        return findPathToModule(parent, MODULE_PATHS);
+    }
 }


### PR DESCRIPTION
This PR adds support for detecting the ts path when [yarn SDKs](https://yarnpkg.com/getting-started/editor-sdks) exist.
This is inspired (and by that I mean copy/pasted and slightly modified 🙂) by the Thiea TypeScript Language server [module resolver script]( https://github.com/typescript-language-server/typescript-language-server/blob/6fe20dac1c28c684cf3214bfdbd98f05225090b9/src/utils/modules-resolver.ts).

If anyone wants to try it out here is a dummy yarn pnp repo.  
https://github.com/predragnikolic/yarn-pnp-example

I have never used yarn pnp, so I had to read about it a bit.
The only thing that I do not know why it exist is the `'.vscode/pnpify/typescript/lib/tsserverlibrary.js'`.
I wanted to remove it, because I do not know why it exist, but I decided to keep, because it cannot hurt.

closes #57 

