### PR TITLE
Support multiple servers

### DIFF
--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -9,6 +9,7 @@
 		}
 	},
 	"settings": {
+		"volar.vueserver.useSecondServer": false,
 		"volar.codeLens.references": true,
 		"volar.codeLens.pugTools": false,
 		"volar.codeLens.scriptSetupTools": false,

--- a/plugin.py
+++ b/plugin.py
@@ -9,10 +9,24 @@ import subprocess
 
 def plugin_loaded():
     LspVolarPlugin.setup()
+    LspVolarSecondServer.setup()
 
 
 def plugin_unloaded():
     LspVolarPlugin.cleanup()
+    LspVolarSecondServer.cleanup()
+
+
+document_features = {
+    "selectionRange": True,
+    "foldingRange": True,
+    "linkedEditingRange": False,
+    "documentSymbol": True,
+    "documentColor": True,
+    "documentFormatting": {
+        "defaultPrintWidth": 90
+    }
+}
 
 
 class LspVolarPlugin(NpmClientHandler):
@@ -30,61 +44,54 @@ class LspVolarPlugin(NpmClientHandler):
     ):
         if not workspace_folders or not configuration:
             return
-        configuration.init_options.set('languageFeatures', {
-            "references": True,
-            "definition": True,
-            "implementation": True,
-            "typeDefinition": True,
-            "callHierarchy": False,
-            "inlayHints": False,
-            "hover": True,
-            "rename": True,
-            "renameFileRefactoring": False,
-            "signatureHelp": True,
-            "codeAction": True,
-            "completion": {
-                "defaultTagNameCase": get_default_tag_name_case(configuration),
-                "defaultAttrNameCase": get_default_attr_name_case(configuration),
-                "getDocumentNameCasesRequest": False,
-                "getDocumentSelectionRequest": False,
-            },
-            "documentHighlight": True,
-            "documentLink": False,
-            "codeLens": False,
-            "semanticTokens": False,
-            "schemaRequestService": False,
-            "diagnostics": True
-        })
-        configuration.init_options.set('documentFeatures', {
-            "selectionRange": True,
-            "foldingRange": True,
-            "linkedEditingRange": False,
-            "documentSymbol": True,
-            "documentColor": True,
-            "documentFormatting": {
-                "defaultPrintWidth": 90
-            }
-        })
+        configuration.init_options.set('languageFeatures', get_language_features(configuration, is_main_server=True))
+        configuration.init_options.set('documentFeatures', document_features)
         if configuration.init_options.get('typescript.serverPath'):
-            return # don't find the `typescript.serverPath` if it was set explicitly in LSP-volar.sublime-settings
-        typescript_path = LspVolarPlugin.find_typescript_path(workspace_folders[0].path)
+            return  # don't find the `typescript.serverPath` if it was set explicitly in LSP-volar.sublime-settings
+        typescript_path = find_typescript_path(LspVolarPlugin, workspace_folders[0].path)
         configuration.init_options.set('typescript.serverPath', typescript_path)
 
+
+class LspVolarSecondServer(LspVolarPlugin):
     @classmethod
-    def find_typescript_path(cls, current_folder: str) -> str:
-        server_directory_path = cls._server_directory_path()
-        resolve_module_script = os.path.join(server_directory_path, 'resolve_module.js')
-        find_ts_server_command =  [cls._node_bin(), resolve_module_script, current_folder]
-        startupinfo = None
-        # Prevent cmd.exe popup on Windows.
-        if sublime.platform() == "windows":
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= (
-                subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW
-            )
-        workspace_ts_path = subprocess.check_output(find_ts_server_command, universal_newlines=True, startupinfo=startupinfo)
-        bundled_ts_path = os.path.join(server_directory_path, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js')
-        return workspace_ts_path or bundled_ts_path
+    def get_displayed_name(cls) -> str:
+        return 'LSP-volar(second server)'
+
+    @classmethod
+    def is_allowed_to_start(
+        cls,
+        window: sublime.Window,
+        initiating_view: Optional[sublime.View] = None,
+        workspace_folders: Optional[List[WorkspaceFolder]] = None,
+        configuration: Optional[ClientConfig] = None
+    ):
+        if not workspace_folders or not configuration:
+            return
+        use_second_server = configuration.settings.get('volar.vueserver.useSecondServer')
+        if not use_second_server:
+            return "Not enabled"
+        configuration.init_options.set('languageFeatures', get_language_features(configuration, is_main_server=False))
+        configuration.init_options.set('documentFeatures', document_features)
+        if configuration.init_options.get('typescript.serverPath'):
+            return  # don't find the `typescript.serverPath` if it was set explicitly in LSP-volar.sublime-settings
+        typescript_path = find_typescript_path(LspVolarSecondServer, workspace_folders[0].path)
+        configuration.init_options.set('typescript.serverPath', typescript_path)
+
+
+def find_typescript_path(plugin, current_folder: str) -> str:
+    server_directory_path = plugin._server_directory_path()
+    resolve_module_script = os.path.join(server_directory_path, 'resolve_module.js')
+    find_ts_server_command =  [plugin._node_bin(), resolve_module_script, current_folder]
+    startupinfo = None
+    # Prevent cmd.exe popup on Windows.
+    if sublime.platform() == "windows":
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= (
+            subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW
+        )
+    workspace_ts_path = subprocess.check_output(find_ts_server_command, universal_newlines=True, startupinfo=startupinfo)
+    bundled_ts_path = os.path.join(server_directory_path, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js')
+    return workspace_ts_path or bundled_ts_path
 
 
 def get_default_tag_name_case(configuration: ClientConfig) -> str:
@@ -101,3 +108,42 @@ def get_default_attr_name_case(configuration: ClientConfig) -> str:
     if preferred_attr_name_case == 'camel':
         return 'camelCase'
     return 'kebabCase'
+
+
+def get_language_features(configuration: ClientConfig, is_main_server: bool) -> dict:
+    use_second_server = configuration.settings.get('volar.vueserver.useSecondServer')
+    main_language_features = {
+        "references": True,
+        "implementation": True,
+        "definition": True,
+        "typeDefinition": True,
+        "callHierarchy": False,
+        "hover": True,
+        "rename": True,
+        "renameFileRefactoring": False,
+        "signatureHelp": True,
+        "codeAction": True,
+        "workspaceSymbol": True,
+        "completion": {
+            "defaultTagNameCase": get_default_tag_name_case(configuration),
+            "defaultAttrNameCase": get_default_attr_name_case(configuration),
+            "getDocumentNameCasesRequest": False,
+            "getDocumentSelectionRequest": False,
+        },
+        "schemaRequestService": False
+    }
+    second_language_features = {
+        "documentHighlight": True,
+        "documentLink": True,
+        "codeLens": {"showReferencesNotification": True},
+        "semanticTokens": True,
+        "inlayHints": False,
+        "diagnostics": True,
+        "schemaRequestService": False
+    }
+    if is_main_server:
+        all_language_features = {}
+        all_language_features.update(main_language_features)
+        all_language_features.update(second_language_features)
+        return main_language_features if use_second_server else all_language_features
+    return second_language_features

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -13,6 +13,11 @@
                 "settings": {
                   "additionalProperties": false,
                   "properties": {
+                    "volar.vueserver.useSecondServer": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Use second server to progress heavy diagnostic works, the main server workhorse computing intellisense, operations such as auto-complete can respond faster. Note that this will lead to more memory usage."
+                    },
                     "volar.codeLens.references": {
                       "type": "boolean",
                       "default": true,


### PR DESCRIPTION
This PR adds a new settings `"volar.vueserver.useSecondServer"`  to support multiple servers.

`Lsp-Volar` will now have two plugins classes `LspVolarPlugin` and `LspVolarSecondServer`.

`LspVolarPlugin` will always start,
but depending on `"volar.vueserver.useSecondServer"` will have different `initializationOptions.languageFeatures` enabled.

`LspVolarSecondServer` will only start if `"volar.vueserver.useSecondServer"` is enabled, 
and will have different `initializationOptions.languageFeatures` enabled from the `LspVolarPlugin` plugin.
