### PR TITLE
Add support for inlay hints LSP-volar

### DIFF
--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -30,6 +30,24 @@
 		// Set --max-old-space-size option on server process. If you have problem on frequently
 		// "Request textDocument/** failed." error, try setting higher memory(MB) on it.
 		"volar.vueserver.maxOldSpaceSize": null,
+
+		// javascript inlay hint
+		"javascript.inlayHints.enumMemberValues.enabled": false,
+		"javascript.inlayHints.functionLikeReturnTypes.enabled": false,
+		"javascript.inlayHints.parameterNames.enabled": "none",
+		"javascript.inlayHints.parameterNames.suppressWhenArgumentMatchesName": false,
+		"javascript.inlayHints.parameterTypes.enabled": false,
+		"javascript.inlayHints.propertyDeclarationTypes.enabled": false,
+		"javascript.inlayHints.variableTypes.enabled": false,
+
+		// typescript inlay hint
+		"typescript.inlayHints.enumMemberValues.enabled": false,
+		"typescript.inlayHints.functionLikeReturnTypes.enabled": false,
+		"typescript.inlayHints.parameterNames.enabled": "none",
+		"typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName": false,
+		"typescript.inlayHints.parameterTypes.enabled": false,
+		"typescript.inlayHints.propertyDeclarationTypes.enabled": false,
+		"typescript.inlayHints.variableTypes.enabled": false,
 	},
 	// ST4
 	"selector": "text.html.vue",

--- a/plugin.py
+++ b/plugin.py
@@ -36,7 +36,7 @@ class LspVolarPlugin(NpmClientHandler):
             "implementation": True,
             "typeDefinition": True,
             "callHierarchy": False,
-            "inlayHints": False,
+            "inlayHints": True,
             "hover": True,
             "rename": True,
             "renameFileRefactoring": False,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -84,6 +84,92 @@
                         "number",
                         "null"
                       ]
+                    },
+                    "typescript.inlayHints.enumMemberValues.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for member values in enum declarations: \n\n ```typescript\n enum MyValue {\n   A /* = 0 */;\n   B /* = 1 */;\n }\n ```\n \n Require TypeScript 4.4+."
+                    },
+                    "typescript.inlayHints.functionLikeReturnTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for implicit return types on function signatures:\n\n ```typescript\n function foo() /* :number */ {\n   return Date.now();\n }\n ```\n Require TypeScript 4.4+."
+                    },
+                    "typescript.inlayHints.parameterTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for parameter names: \n\n ```typescript\n parseInt(/* str: */ '123', /* radix: */ 8)\n ```\n Require TypeScript 4.4+."
+                    },
+                    "typescript.inlayHints.parameterNames.enabled": {
+                      "enum": [
+                        "all",
+                        "literals",
+                        "none"
+                      ],
+                      "default": "none",
+                      "markdownEnumDescriptions": [
+                        "Enable parameter name hints for literal and non-literal arguments.",
+                        "Enable parameter name hints only for literal arguments.",
+                        "Disable parameter name hints."
+                      ]
+                    },
+                    "typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": ""
+                    },
+                    "typescript.inlayHints.propertyDeclarationTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for implicit types on property declarations: \n\n ```typescript\n class Foo {\n   prop /* :number */ = Date.now;\n }\n ```\n Require TypeScript 4.4+."
+                    },
+                    "typescript.inlayHints.variableTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for implicit variable types: \n\n ```typescript\n const foo /* :number */ = Date.now();\n ``` \n Require TypeScript 4.4+."
+                    },
+                    "javascript.inlayHints.enumMemberValues.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for member values in enum declarations: \n\n ```typescript\n enum MyValue {\n   A /* = 0 */;\n   B /* = 1 */;\n }\n ```\n \n Require TypeScript 4.4+."
+                    },
+                    "javascript.inlayHints.functionLikeReturnTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for implicit return types on function signatures:\n\n ```typescript\n function foo() /* :number */ {\n   return Date.now();\n }\n ```\n Require TypeScript 4.4+."
+                    },
+                    "javascript.inlayHints.parameterTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for parameter names: \n\n ```typescript\n parseInt(/* str: */ '123', /* radix: */ 8)\n ```\n Require TypeScript 4.4+."
+                    },
+                    "javascript.inlayHints.parameterNames.enabled": {
+                      "enum": [
+                        "all",
+                        "literals",
+                        "none"
+                      ],
+                      "default": "none",
+                      "markdownEnumDescriptions": [
+                        "Enable parameter name hints for literal and non-literal arguments.",
+                        "Enable parameter name hints only for literal arguments.",
+                        "Disable parameter name hints."
+                      ]
+                    },
+                    "javascript.inlayHints.parameterNames.suppressWhenArgumentMatchesName": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": ""
+                    },
+                    "javascript.inlayHints.propertyDeclarationTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for implicit types on property declarations: \n\n ```typescript\n class Foo {\n   prop /* :number */ = Date.now;\n }\n ```\n Require TypeScript 4.4+."
+                    },
+                    "javascript.inlayHints.variableTypes.enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "markdownDescription": "Enable/disable inlay hints for implicit variable types: \n\n ```typescript\n const foo /* :number */ = Date.now();\n ``` \n Require TypeScript 4.4+."
                     }
                   }
                 }


### PR DESCRIPTION
Inlay hints need to be implemented in the LSP repo in order for this to work.