### PR TITLE
disable code lens by default

### DIFF
--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -72,5 +72,8 @@
 			"scopes": ["text.html.vue"],
 			"syntaxes": ["Packages/Vue Syntax Highlight/Vue Component.sublime-syntax"],
 		}
-	]
+	],
+	"disabled_capabilities": {
+		"codeLensProvider": true
+	}
 }


### PR DESCRIPTION
to not clutter the UI. 
Also we do not implement the logic when code lens are clicked.