### PR TITLE
set NODE_ENV=production for volar

### DIFF
--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -275,6 +275,9 @@
 		"${server_path}",
 		"--stdio"
 	],
+	"env": {
+		"NODE_ENV": "production",
+	},
 	// ST4
 	"selector": "text.html.vue",
 	// ST3

--- a/LSP-volar.sublime-settings
+++ b/LSP-volar.sublime-settings
@@ -278,18 +278,5 @@
 	"env": {
 		"NODE_ENV": "production",
 	},
-	// ST4
 	"selector": "text.html.vue",
-	// ST3
-	"languages": [
-		{
-			"languageId": "vue",
-			"scopes": [
-				"text.html.vue"
-			],
-			"syntaxes": [
-				"Packages/Vue Syntax Highlight/Vue Component.sublime-syntax"
-			],
-		}
-	]
 }


### PR DESCRIPTION
Using Volar in a project with latest Vue version (2.7.16) reveals an issue when using `transition` element that is caused by the fact that `@vue/compiler-dom` runs in a non-production mode.

Volar VSCode extension doesn't show this issue because it bundles its whole code with NODE_ENV set to "production". We could do the same in this package which would make installation faster, server code smaller and would not require running `npm install` (which can avoid some problems) but that's more effort.

See also https://github.com/vuejs/language-tools/issues/3881 for more detailed explanation of the issue.